### PR TITLE
Add coin detail view with chart

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,23 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { SafeAreaProvider } from 'react-native-safe-area-context';
+import React, { useState } from 'react';
 import { Home } from "./Home";
+import { Details } from './Details';
 
 const queryClient = new QueryClient()
 
 export function App() {
-    return (
-        <SafeAreaProvider>
-            <QueryClientProvider client={queryClient}>
-                <Home />
-            </QueryClientProvider>
-        </SafeAreaProvider>
-    )
-  }
+  const [selectedCoin, setSelectedCoin] = useState<string | null>(null);
+
+  return (
+    <SafeAreaProvider>
+      <QueryClientProvider client={queryClient}>
+        {selectedCoin ? (
+          <Details id={selectedCoin} onClose={() => setSelectedCoin(null)} />
+        ) : (
+          <Home onSelectCoin={setSelectedCoin} />
+        )}
+      </QueryClientProvider>
+    </SafeAreaProvider>
+  );
+}

--- a/src/Details/Chart.tsx
+++ b/src/Details/Chart.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import Svg, { Path } from 'react-native-svg';
+
+interface Props {
+  data: number[];
+  width: number;
+  height: number;
+  color?: string;
+}
+
+export function Chart({ data, width, height, color = '#6200ee' }: Props) {
+  if (data.length === 0) {
+    return null;
+  }
+
+  const max = Math.max(...data);
+  const min = Math.min(...data);
+  const range = max - min || 1;
+  const stepX = width / (data.length - 1);
+
+  const path = data
+    .map((value, index) => {
+      const x = index * stepX;
+      const y = height - ((value - min) / range) * height;
+      const prefix = index === 0 ? 'M' : 'L';
+      return `${prefix}${x},${y}`;
+    })
+    .join(' ');
+
+  return (
+    <Svg width={width} height={height}>
+      <Path d={path} fill="none" stroke={color} strokeWidth={2} />
+    </Svg>
+  );
+}

--- a/src/Details/details.hook.ts
+++ b/src/Details/details.hook.ts
@@ -1,0 +1,36 @@
+import { useQuery } from '@tanstack/react-query';
+import axios from 'axios';
+
+async function fetchDetails(id: string) {
+  const { data } = await axios.get(`https://api.coingecko.com/api/v3/coins/${id}`, {
+    params: {
+      localization: false,
+      tickers: false,
+      market_data: true,
+      community_data: false,
+      developer_data: false,
+      sparkline: false,
+    },
+  });
+  return data;
+}
+
+async function fetchPrices(id: string) {
+  const { data } = await axios.get(`https://api.coingecko.com/api/v3/coins/${id}/market_chart`, {
+    params: {
+      vs_currency: 'brl',
+      days: 7,
+    },
+  });
+  return data.prices as number[][];
+}
+
+export function useCoinDetails(id: string) {
+  return useQuery({
+    queryKey: ['coin', id],
+    queryFn: async () => {
+      const [details, prices] = await Promise.all([fetchDetails(id), fetchPrices(id)]);
+      return { details, prices };
+    },
+  });
+}

--- a/src/Details/index.tsx
+++ b/src/Details/index.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { ActivityIndicator, Button, Dimensions, ScrollView, Text, View, Image } from 'react-native';
+import { formatCurrency } from '../utils/formatCurrency';
+import { Chart } from './Chart';
+import { useCoinDetails } from './details.hook';
+
+interface Props {
+  id: string;
+  onClose: () => void;
+}
+
+export function Details({ id, onClose }: Props) {
+  const { data, isLoading } = useCoinDetails(id);
+  const width = Dimensions.get('window').width - 32;
+
+  if (isLoading || !data) {
+    return <ActivityIndicator size="large" color="#6200ee" style={{ flex: 1 }} />;
+  }
+
+  const { details, prices } = data;
+  const market = details.market_data;
+
+  return (
+    <ScrollView contentContainerStyle={{ padding: 16 }}>
+      <Button title="Voltar" onPress={onClose} />
+      <View style={{ alignItems: 'center', marginVertical: 16 }}>
+        <Image source={{ uri: details.image.large }} style={{ width: 64, height: 64 }} />
+        <Text style={{ fontSize: 24, fontWeight: '700' }}>{details.name}</Text>
+        <Text style={{ fontSize: 16 }}>{details.symbol.toUpperCase()}</Text>
+      </View>
+      <Chart data={prices.map(p => p[1])} width={width} height={200} />
+      <View style={{ marginTop: 16 }}>
+        <Text>Preço atual: {formatCurrency(market.current_price.brl)}</Text>
+        <Text>Maior 24h: {formatCurrency(market.high_24h.brl)}</Text>
+        <Text>Menor 24h: {formatCurrency(market.low_24h.brl)}</Text>
+        <Text>Capitalização: {formatCurrency(market.market_cap.brl)}</Text>
+        <Text>Variação 24h: {market.price_change_percentage_24h.toFixed(2)}%</Text>
+      </View>
+    </ScrollView>
+  );
+}

--- a/src/Home/components/CoinItem.tsx
+++ b/src/Home/components/CoinItem.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react';
-import { View, Text, Image, StyleSheet, Platform, Animated } from 'react-native';
+import { View, Text, Image, StyleSheet, Platform, Animated, Pressable } from 'react-native';
 import { CaretUp, CaretDown } from 'phosphor-react-native';
 import { formatCurrency } from '../../utils/formatCurrency';
 import { isPriceUp } from '../../utils/isPriceUp';
@@ -12,9 +12,10 @@ type Props = {
   image: string;
   changePercentage: number;
   index: number;
+  onPress: () => void;
 };
 
-export const CoinItem = React.memo(({ name, symbol, price, image, changePercentage, index }: Props) => {
+export const CoinItem = React.memo(({ name, symbol, price, image, changePercentage, index, onPress }: Props) => {
   const isUp = isPriceUp(changePercentage);
   const slideAnim = useRef(new Animated.Value(100)).current; // Começa fora da tela (direita)
   const opacityAnim = useRef(new Animated.Value(0)).current;
@@ -37,28 +38,34 @@ export const CoinItem = React.memo(({ name, symbol, price, image, changePercenta
   }, []);
 
   return (
-    <Animated.View
-      style={[
-        styles.container,
-        {
-          transform: [{ translateX: slideAnim }],
-          opacity: opacityAnim,
-        },
-      ]}
-    >
-        <BlurView intensity={20} tint='light' style={StyleSheet.absoluteFill}/>
-      <View style={styles.left}>
-        <Image source={{ uri: image }} style={styles.image} />
-        <View>
-            <Text style={styles.name} numberOfLines={1} ellipsizeMode="tail">{name}</Text>
+    <Pressable onPress={onPress} disabled={!onPress}>
+      <Animated.View
+        style={[
+          styles.container,
+          {
+            transform: [{ translateX: slideAnim }],
+            opacity: opacityAnim,
+          },
+        ]}
+      >
+        <BlurView intensity={20} tint="light" style={StyleSheet.absoluteFill} />
+        <View style={styles.left}>
+          <Image source={{ uri: image }} style={styles.image} />
+          <View>
+            <Text style={styles.name} numberOfLines={1} ellipsizeMode="tail">
+              {name}
+            </Text>
             <Text style={styles.symbol}>{symbol.toUpperCase()}</Text>
+          </View>
         </View>
-      </View>
-      <View style={styles.right}>
-        <Text style={styles.price}>{formatCurrency(price)}</Text>
-        <Text style={[styles.price, isUp ? styles.up : styles.down]}>{changePercentage.toFixed(2)}%</Text>
-      </View>
-    </Animated.View>
+        <View style={styles.right}>
+          <Text style={styles.price}>{formatCurrency(price)}</Text>
+          <Text style={[styles.price, isUp ? styles.up : styles.down]}>
+            {changePercentage.toFixed(2)}%
+          </Text>
+        </View>
+      </Animated.View>
+    </Pressable>
   );
 });
 

--- a/src/Home/index.tsx
+++ b/src/Home/index.tsx
@@ -1,15 +1,17 @@
 import React from 'react';
-import { FlatList, Image, RefreshControl, Text, View, ActivityIndicator, ImageBackground } from 'react-native';
+import { FlatList, RefreshControl, Text, View, ActivityIndicator, ImageBackground } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { useCoins } from './home.hook';
-import { formatCurrency } from '../utils/formatCurrency';
-import { CaretUp, CaretDown } from 'phosphor-react-native';
-import { isPriceUp } from '../utils/isPriceUp';
+
 import { CoinItem } from './components/CoinItem';
 
 
-export function Home() {
+type Props = {
+  onSelectCoin: (id: string) => void;
+};
+
+export function Home({ onSelectCoin }: Props) {
   const {
     data,
     isLoading,
@@ -61,7 +63,7 @@ return (
             </View>
           </View>
         )}
-        renderItem={({ item, index }) => 
+        renderItem={({ item, index }) => (
           <CoinItem
             name={item.name}
             symbol={item.symbol}
@@ -69,8 +71,9 @@ return (
             image={item.image}
             changePercentage={item.price_change_percentage_24h}
             index={index}
+            onPress={() => onSelectCoin(item.id)}
           />
-      }
+        )}
       />
     </SafeAreaView>
   </ImageBackground>


### PR DESCRIPTION
## Summary
- allow selecting coins in list
- create details screen using CoinGecko info
- add simple line chart using react-native-svg
- switch between home and details screens

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'expo' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6859d4bc987883339f023e77d97e588f